### PR TITLE
fix bug in spm encode

### DIFF
--- a/scripts/spm_encode.py
+++ b/scripts/spm_encode.py
@@ -56,11 +56,11 @@ def main():
 
     with contextlib.ExitStack() as stack:
         inputs = [
-            stack.enter_context(open(input, "r", encoding="utf-8"))
+            stack.enter_context(open(input, "r", encoding="utf-8", newline="\n"))
             for input in args.inputs
         ]
         outputs = [
-            stack.enter_context(open(output, "w", encoding="utf-8"))
+            stack.enter_context(open(output, "w", encoding="utf-8", newline="\n"))
             for output in args.outputs
         ]
 


### PR DESCRIPTION
Fix a bug that could potentially lead to source-target sentence misalignment if there are carriage returns in the raw text.